### PR TITLE
Update conda-forge.yml to include additional platforms

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,7 +1,13 @@
 conda_build_tool: rattler-build
+build_platform:
+  osx_arm64: osx_64
 github:
   branch_name: main
   tooling_branch_name: main
 conda_build:
   error_overlinking: true
 conda_forge_output_validation: true
+provider:
+  linux_aarch64: default
+  linux_ppc64le: default
+test: native_and_emulated

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -11,7 +11,7 @@ source:
   sha256: e28bec9a54f890e4af0c3ffeab3c12727eb55f684573cb651e97594b46f17630
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
This pull request updates the `conda-forge.yml` configuration file to enhance platform support and testing capabilities. The changes include specifying build platforms for macOS and adding configuration for providers and testing.

Configuration updates:

* Added `build_platform` to specify that `osx_arm64` builds should use the `osx_64` platform.
* Introduced a `provider` section to define default providers for `linux_aarch64` and `linux_ppc64le`.
* Added a `test` configuration to enable both native and emulated testing.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
